### PR TITLE
Changing superuser to false in all author index files

### DIFF
--- a/content/authors/melody/_index.md
+++ b/content/authors/melody/_index.md
@@ -7,7 +7,7 @@ authors:
 - melody
 
 # Is this the primary user of the site?
-superuser: true
+superuser: false
 
 # Role/position
 role: Graduate Student - Research Assistant

--- a/content/authors/rae/_index.md
+++ b/content/authors/rae/_index.md
@@ -7,7 +7,7 @@ authors:
 - rae
 
 # Is this the primary user of the site?
-superuser: true
+superuser: false
 
 # Role/position
 role: Graduate Student


### PR DESCRIPTION
Glitch w/ clicking names at the bottom of protocols (only @ the bottom) taking back to Fuhrman lab home page. Resolution = changing Superuser setting to = false in all /content/author/'name'/_index files.